### PR TITLE
Added department to the meta data at the top of all pages

### DIFF
--- a/source/layouts/design_pattern.erb
+++ b/source/layouts/design_pattern.erb
@@ -26,6 +26,8 @@
           <dd>15/03/2017</dd>                      
           <dt>Edit on:</dt>
           <dd><a href="<%= current_page.data.edit %>">Github</a></dd>
+          <dt>Department</dt>
+          <dd><a href="<%= current_page.data.department %>"><%= current_page.data.department %></a></dd>
         </dl>
       </div>
     </div>


### PR DESCRIPTION
So that we can see which patterns are HMRC patterns and differentiate them from other patterns I've pulled out the meta from the `department` tag on to the patterns page template.

<img width="305" alt="screenshot 2017-03-30 11 30 04" src="https://cloud.githubusercontent.com/assets/868772/24500176/43a8e06c-153c-11e7-8c1f-3d98be821056.png">

In the future we may want to do more with this to show in the nav that a pattern is from a particular department.
